### PR TITLE
Fix go tools at module roots

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -757,18 +757,13 @@ Mismatch between versions requested for Go module {module}:
                 # Skip major version
                 tool_name = segments[-2]
             pkg_path = tool_path[len(module_path):].lstrip("/")
-            if pkg_path:
-                tool_targets[tool_name] = "@{repo}//{pkg}".format(
-                    repo = importpath_to_repo[module_path],
-                    pkg = pkg_path,
-                )
-            else:
-                # When tool is at module root (e.g., mvdan.cc/gofumpt),
-                # the target should be @repo//:tool_name
-                tool_targets[tool_name] = "@{repo}//:{tool}".format(
-                    repo = importpath_to_repo[module_path],
-                    tool = tool_name,
-                )
+            # Always use explicit target name format: @repo//pkg:target
+            # When pkg_path is empty (tool at module root), this becomes @repo//:tool_name
+            tool_targets[tool_name] = "@{repo}//{pkg}:{tool}".format(
+                repo = importpath_to_repo[module_path],
+                pkg = pkg_path,
+                tool = tool_name,
+            )
 
     # Create a synthetic WORKSPACE file that lists all Go repositories created
     # above and contains all the information required by Gazelle's -repo_config

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -752,17 +752,22 @@ Mismatch between versions requested for Go module {module}:
                 break
 
         if module_path:
-            tool_name = segments[-1]
+            # The target name is always the last segment of the tool path (e.g., "staticcheck", "v2", "gofumpt")
+            target_name = segments[-1]
+
+            # The dictionary key strips version suffixes for user-friendly lookup (e.g., "tool" not "v2")
+            tool_name = target_name
             if len(segments) >= 2 and len(tool_name) >= 2 and tool_name[0] == "v" and tool_name[1:].isdigit():
-                # Skip major version
+                # Skip major version for the dictionary key
                 tool_name = segments[-2]
+
             pkg_path = tool_path[len(module_path):].lstrip("/")
-            # Always use explicit target name format: @repo//pkg:target
-            # When pkg_path is empty (tool at module root), this becomes @repo//:tool_name
-            tool_targets[tool_name] = "@{repo}//{pkg}:{tool}".format(
+            # Always use explicit target syntax: @repo//pkg:target
+            # This works for both subdirectories and module root
+            tool_targets[tool_name] = "@{repo}//{pkg}:{target}".format(
                 repo = importpath_to_repo[module_path],
                 pkg = pkg_path,
-                tool = tool_name,
+                target = target_name,
             )
 
     # Create a synthetic WORKSPACE file that lists all Go repositories created

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -757,10 +757,18 @@ Mismatch between versions requested for Go module {module}:
                 # Skip major version
                 tool_name = segments[-2]
             pkg_path = tool_path[len(module_path):].lstrip("/")
-            tool_targets[tool_name] = "@{repo}//{pkg}".format(
-                repo = importpath_to_repo[module_path],
-                pkg = pkg_path,
-            )
+            if pkg_path:
+                tool_targets[tool_name] = "@{repo}//{pkg}".format(
+                    repo = importpath_to_repo[module_path],
+                    pkg = pkg_path,
+                )
+            else:
+                # When tool is at module root (e.g., mvdan.cc/gofumpt),
+                # the target should be @repo//:tool_name
+                tool_targets[tool_name] = "@{repo}//:{tool}".format(
+                    repo = importpath_to_repo[module_path],
+                    tool = tool_name,
+                )
 
     # Create a synthetic WORKSPACE file that lists all Go repositories created
     # above and contains all the information required by Gazelle's -repo_config

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -752,18 +752,12 @@ Mismatch between versions requested for Go module {module}:
                 break
 
         if module_path:
-            # The target name is always the last segment of the tool path (e.g., "staticcheck", "v2", "gofumpt")
-            target_name = segments[-1]
-
-            # The dictionary key strips version suffixes for user-friendly lookup (e.g., "tool" not "v2")
-            tool_name = target_name
+            tool_name = segments[-1]
+            target_name = tool_name
             if len(segments) >= 2 and len(tool_name) >= 2 and tool_name[0] == "v" and tool_name[1:].isdigit():
-                # Skip major version for the dictionary key
+                # Skip major version
                 tool_name = segments[-2]
-
             pkg_path = tool_path[len(module_path):].lstrip("/")
-            # Always use explicit target syntax: @repo//pkg:target
-            # This works for both subdirectories and module root
             tool_targets[tool_name] = "@{repo}//{pkg}:{target}".format(
                 repo = importpath_to_repo[module_path],
                 pkg = pkg_path,

--- a/tests/bcr/go_mod/go.mod
+++ b/tests/bcr/go_mod/go.mod
@@ -55,3 +55,4 @@ require (
 replace example.org/hello => ../../fixtures/hello
 
 tool honnef.co/go/tools/cmd/staticcheck
+tool mvdan.cc/gofumpt

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -73,12 +73,13 @@ _PackageInfoSubjectFactory = struct(
 )
 
 def starlark_tests(name):
+    # Test tool in subdirectory (explicit label syntax)
     if "staticcheck" not in GO_TOOLS:
         fail("Expected 'staticcheck' in 'GO_TOOLS'")
     if GO_TOOLS["staticcheck"] != Label("@co_honnef_go_tools//cmd/staticcheck:staticcheck"):
         fail("Unexpected value for 'staticcheck': {}".format(GO_TOOLS["staticcheck"]))
 
-    # Test case for tools at module root (e.g., mvdan.cc/gofumpt)
+    # Test tool at module root (explicit label syntax)
     if "gofumpt" not in GO_TOOLS:
         fail("Expected 'gofumpt' in 'GO_TOOLS'")
     if GO_TOOLS["gofumpt"] != Label("@cc_mvdan_gofumpt//:gofumpt"):

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -73,13 +73,10 @@ _PackageInfoSubjectFactory = struct(
 )
 
 def starlark_tests(name):
-    # Test tool in subdirectory (explicit label syntax)
     if "staticcheck" not in GO_TOOLS:
         fail("Expected 'staticcheck' in 'GO_TOOLS'")
     if GO_TOOLS["staticcheck"] != Label("@co_honnef_go_tools//cmd/staticcheck:staticcheck"):
         fail("Unexpected value for 'staticcheck': {}".format(GO_TOOLS["staticcheck"]))
-
-    # Test tool at module root (explicit label syntax)
     if "gofumpt" not in GO_TOOLS:
         fail("Expected 'gofumpt' in 'GO_TOOLS'")
     if GO_TOOLS["gofumpt"] != Label("@cc_mvdan_gofumpt//:gofumpt"):

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -75,7 +75,7 @@ _PackageInfoSubjectFactory = struct(
 def starlark_tests(name):
     if "staticcheck" not in GO_TOOLS:
         fail("Expected 'staticcheck' in 'GO_TOOLS'")
-    if GO_TOOLS["staticcheck"] != Label("@co_honnef_go_tools//cmd/staticcheck"):
+    if GO_TOOLS["staticcheck"] != Label("@co_honnef_go_tools//cmd/staticcheck:staticcheck"):
         fail("Unexpected value for 'staticcheck': {}".format(GO_TOOLS["staticcheck"]))
 
     # Test case for tools at module root (e.g., mvdan.cc/gofumpt)

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -78,6 +78,12 @@ def starlark_tests(name):
     if GO_TOOLS["staticcheck"] != Label("@co_honnef_go_tools//cmd/staticcheck"):
         fail("Unexpected value for 'staticcheck': {}".format(GO_TOOLS["staticcheck"]))
 
+    # Test case for tools at module root (e.g., mvdan.cc/gofumpt)
+    if "gofumpt" not in GO_TOOLS:
+        fail("Expected 'gofumpt' in 'GO_TOOLS'")
+    if GO_TOOLS["gofumpt"] != Label("@cc_mvdan_gofumpt//:gofumpt"):
+        fail("Unexpected value for 'gofumpt': {}".format(GO_TOOLS["gofumpt"]))
+
     test_suite(
         name = name,
         tests = [

--- a/tests/bcr/go_mod/tools/BUILD.bazel
+++ b/tests/bcr/go_mod/tools/BUILD.bazel
@@ -11,7 +11,7 @@ alias(
 
 alias(
     name = "staticcheck",
-    actual = "@co_honnef_go_tools//cmd/staticcheck",
+    actual = "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
 )
 
 alias(

--- a/tests/bcr/go_mod/tools/BUILD.bazel
+++ b/tests/bcr/go_mod/tools/BUILD.bazel
@@ -13,3 +13,8 @@ alias(
     name = "staticcheck",
     actual = "@co_honnef_go_tools//cmd/staticcheck",
 )
+
+alias(
+    name = "gofumpt",
+    actual = "@cc_mvdan_gofumpt//:gofumpt",
+)


### PR DESCRIPTION
bazel-contrib/bazel-gazelle#2215 did not correctly handle tools like `mvdan.cc/gofumpt` where the tool is located at the root of the module. This PR addresses that.